### PR TITLE
normalizing font size for mc header when used in both old layout and new

### DIFF
--- a/src/scss/core.scss
+++ b/src/scss/core.scss
@@ -686,8 +686,10 @@ $mc-condensed-ease-timing: 450ms;
   position: fixed;
   top: 0; left: 0;
   width: 100%;
-  text-align: center; // needed to center wordmark
+  text-align: center;
   text-transform: uppercase;
+  font-size: 16px;
+  line-height: 1;
   background: #000;
   padding: 1em;
   z-index: 10;


### PR DESCRIPTION
The old layout uses different body font size and line height, this normalizes the header for both the old layout and new one